### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -16,21 +16,11 @@
       "inputs": ["default", "^production"],
       "cache": true
     },
-    "codegen": {
-      "dependsOn": ["^codegen", "^build"],
-      "cache": true
-    },
-    "publish": {
-      "dependsOn": ["build"],
-      "cache": false
-    },
-    "serve": {
-      "dependsOn": ["^codegen"]
-    },
+    "codegen": { "dependsOn": ["^codegen", "^build"], "cache": true },
+    "publish": { "dependsOn": ["build"], "cache": false },
+    "serve": { "dependsOn": ["^codegen"] },
     "@nx-dotnet/core:test": {
-      "options": {
-        "noBuild": true
-      },
+      "options": { "noBuild": true },
       "dependsOn": ["build"]
     },
     "@nx-dotnet/core:build": {
@@ -47,10 +37,7 @@
     "production": ["default"],
     "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
   },
-  "workspaceLayout": {
-    "appsDir": "apps",
-    "libsDir": "libs"
-  },
+  "workspaceLayout": { "appsDir": "apps", "libsDir": "libs" },
   "plugins": [
     {
       "plugin": "@nx-dotnet/core",
@@ -72,5 +59,6 @@
         "typecheckTargetName": "typecheck"
       }
     }
-  ]
+  ],
+  "nxCloudId": "6841cdf4b552c0901bef4464"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/683495532abd09ea0c60ef33/workspaces/6841cdf4b552c0901bef4464

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.